### PR TITLE
Remove needless and potentially harmful `sudo`'s

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ There's also a lot of standard libraries available for C++ and that might be an 
 # Quick Start
 Use this command to install Hajime in one step. It will download and compile the latest version available on GitHub.
 
-    curl -o install.sh https://raw.githubusercontent.com/Slackadays/Hajime/master/install.sh && sudo sh install.sh
+    curl -o install.sh https://raw.githubusercontent.com/Slackadays/Hajime/master/install.sh && sh install.sh
 
 Like with all shell scripts, before running, make sure to review the install.sh file to check for any potentially malicious commands.
 
@@ -40,7 +40,7 @@ again. Server.conf is the settings file for an individual server object. This is
 # Compiling Your Own
 It's easy to compile Hajime. First, download the files in the **source** section. Then, run this command:
 
-    sudo g++ -std=c++20 -Ofast -o hajime hajime.cpp
+    g++ -std=c++20 -Ofast -o hajime hajime.cpp
     
 Hajime requires at least C++17 to work.
    

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo "\e[1mInstalling g++ and git...\e[0m"
-apt update && apt install -y g++ git #g++-10 or the otherwise latest version of g++ that supports c++17
+sudo apt update && sudo apt install -y g++ git #g++-10 or the otherwise latest version of g++ that supports c++17
 echo "\e[1mDownloading...\e[0m"
 git clone https://github.com/Slackadays/Hajime
 echo "\e[1mCompiling...\e[0m"


### PR DESCRIPTION
Root privileges aren't required to compile or clone this program; you only need `sudo` to use it and install its dependencies.